### PR TITLE
Match Siege/ instead of Siege

### DIFF
--- a/BrowserDetection.php
+++ b/BrowserDetection.php
@@ -32,7 +32,7 @@ class BrowserDetection
             'PhantomJS',
             'Electron',
             'ApacheBench', // Load test
-            'Siege', // Load test
+            'Siege/', // Load test
             'https://k6.io/', // Load test, Added full URL to handle case where UA can be fook6bar or fook6/
             'Radview', // Load test
             'Locust', // Load test


### PR DESCRIPTION
just in case a different user agent contains it so it matches better
