### PR TITLE
Block digital ocean additionally through providers

### DIFF
--- a/Configuration.php
+++ b/Configuration.php
@@ -13,7 +13,7 @@ class Configuration
 {
     const DEFAULT_RANGE_THROW_EXCEPTION = 0;
     const DEFAULT_RANGE_ALLOW_LIST = [''];
-    const DEFAULT_GEOIP_MATCH_PROVIDERS = ['alicloud', 'alibaba cloud'];
+    const DEFAULT_GEOIP_MATCH_PROVIDERS = ['alicloud', 'alibaba cloud', 'digitalocean', 'digital ocean'];
 
     const KEY_RANGE_THROW_EXCEPTION = 'block_cloud_sync_throw_exception_on_error';
     const KEY_RANGE_ALLOW_LIST = 'iprange_allowlist';

--- a/tests/Integration/ConfigurationTest.php
+++ b/tests/Integration/ConfigurationTest.php
@@ -41,7 +41,7 @@ class ConfigurationTest extends IntegrationTestCase
         $this->assertEquals(array(
             'block_cloud_sync_throw_exception_on_error' => 0,
             'iprange_allowlist' => [''],
-            'block_geoip_organisations' => ['alicloud', 'alibaba cloud'],
+            'block_geoip_organisations' => ['alicloud', 'alibaba cloud', 'digitalocean', 'digital ocean'],
         ), $configs);
     }
 


### PR DESCRIPTION
### Description:

Noticed recently some blocked IP from digital ocean that didn't appear in their CSV but the GeoIP DBs detected it as an organisation.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
