### PR TITLE
Added code to not check geoip db if usercountry is disabled

### DIFF
--- a/BlockedGeoIp.php
+++ b/BlockedGeoIp.php
@@ -59,7 +59,7 @@ class BlockedGeoIp
 
     public function isExcludedProvider($ip, $language)
     {
-        if (empty($this->blockedProviders)) {
+        if (empty($this->blockedProviders) || !(\Piwik\Plugin\Manager::getInstance()->isPluginActivated('UserCountry'))) {
             return false;
         }
         $result = $this->detectLocation($ip, $language);

--- a/tests/Integration/BlockedGeoIpTest.php
+++ b/tests/Integration/BlockedGeoIpTest.php
@@ -63,5 +63,10 @@ class BlockedGeoIpTest extends IntegrationTestCase
         $this->assertFalse($this->blockedGeoIp->isExcludedProvider('127.0.0.1', 'en'));
     }
 
+    public function test_isExcluded_When_UserCountryPluginIsDisabled()
+    {
+        \Piwik\Plugin\Manager::getInstance()->deactivatePlugin('UserCountry');
+        $this->assertFalse($this->blockedGeoIp->isExcludedProvider('127.0.0.1', 'en'));
+    }
 
 }


### PR DESCRIPTION
### Description:

Added code to not check geoip db if usercountry is disabled
Fixes: #41

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
