### PR TITLE
Fixed azure IP ranges download URL parsing from HTML

### DIFF
--- a/BlockedIpRanges/Azure.php
+++ b/BlockedIpRanges/Azure.php
@@ -61,7 +61,7 @@ class Azure implements IpRangeProviderInterface
         $posStart = strpos($contentDownloadPage, $prefixUrl . 'https://download.microsoft.com/download/');
         $posEnd = strpos($contentDownloadPage, '.json"', $posStart + strlen($prefixUrl)); // we don't want to match the " in href="
         $contentDownloadPage = Common::mb_substr($contentDownloadPage, $posStart - strlen($prefixUrl) + 2,
-          $posEnd - $posStart - strlen($prefixUrl) + 2);
+          $posEnd - $posStart - strlen($prefixUrl));
         $downloadUrl = trim($contentDownloadPage, '="' . "'") . '.json';
         $downloadUrl = trim($downloadUrl);
 


### PR DESCRIPTION
### Description:

Fixed azure IP ranges download URL parsing from HTML.

We download Azure IP ranges 1st by calling the azure page and parses the HTML page to get the download URL
Probably new element was added which was breaking this download parsing and was adding and extra `.j` due to which wrong URL was being formed.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
