### PR TITLE
Removed PHP 7.4 from builds in favor of PHP 8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: php
 
 php:
   - 7.2
-  - 7.4
 #  - hhvm
 
 services:
@@ -42,12 +41,18 @@ matrix:
     # execute latest stable tests only w/ PHP 5.6
     - php: 7.2
       env: TEST_SUITE=PluginTests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_CORE=minimum_required_piwik
-    # execute UI tests only w/ PHP 5.6
-    - php: 7.4
-      env: TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_PIWIK_BRANCH=$PIWIK_TEST_TARGET
   include:
     - php: 8.1
       env: TEST_SUITE=PluginTests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_PIWIK_BRANCH=$PIWIK_TEST_TARGET SKIP_COMPOSER_INSTALL=1
+      script:
+        - cd $PIWIK_ROOT_DIR
+        - composer install --ignore-platform-reqs
+        - composer remove --dev phpunit/phpunit
+        - composer require --dev phpunit/phpunit ~9.3 --ignore-platform-reqs
+        - cd tests/PHPUnit
+        - $PIWIK_ROOT_DIR/tests/travis/travis.sh
+    - php: 8.1
+      env: TEST_SUITE=PluginTests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_CORE=minimum_required_piwik SKIP_COMPOSER_INSTALL=1
       script:
         - cd $PIWIK_ROOT_DIR
         - composer install --ignore-platform-reqs
@@ -82,7 +87,7 @@ install:
   - '[ -d ./tests/travis/.git ] || sh -c "rm -rf ./tests/travis && git clone https://github.com/matomo-org/travis-scripts.git ./tests/travis"'
   - cd ./tests/travis ; git checkout master ; cd ../..
 
-  - export GENERATE_TRAVIS_YML_COMMAND="php ./tests/travis/generator/main.php generate:travis-yml --plugin=\"TrackingSpamPrevention\" --php-versions=\"7.2,7.4\" --distribution=\"bionic\" --sudo-false --verbose"
+  - export GENERATE_TRAVIS_YML_COMMAND="php ./tests/travis/generator/main.php generate:travis-yml --plugin=\"TrackingSpamPrevention\" --php-versions=\"7.2\" --distribution=\"bionic\" --sudo-false --verbose"
   - '[[ "$TRAVIS_JOB_NUMBER" != *.1 || "$TRAVIS_PULL_REQUEST" != "false" ]] || ./tests/travis/autoupdate_travis_yml.sh'
 
   - ./tests/travis/checkout_test_against_branch.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,15 +51,16 @@ matrix:
         - composer require --dev phpunit/phpunit ~9.3 --ignore-platform-reqs
         - cd tests/PHPUnit
         - $PIWIK_ROOT_DIR/tests/travis/travis.sh
-    - php: 8.1
-      env: TEST_SUITE=PluginTests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_CORE=minimum_required_piwik SKIP_COMPOSER_INSTALL=1
-      script:
-        - cd $PIWIK_ROOT_DIR
-        - composer install --ignore-platform-reqs
-        - composer remove --dev phpunit/phpunit
-        - composer require --dev phpunit/phpunit ~9.3 --ignore-platform-reqs
-        - cd tests/PHPUnit
-        - $PIWIK_ROOT_DIR/tests/travis/travis.sh
+# The minimum version of Matomo doesn't support PHP 8.1, so we're excluding it for now
+#    - php: 8.1
+#      env: TEST_SUITE=PluginTests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_CORE=minimum_required_piwik SKIP_COMPOSER_INSTALL=1
+#      script:
+#        - cd $PIWIK_ROOT_DIR
+#        - composer install --ignore-platform-reqs
+#        - composer remove --dev phpunit/phpunit
+#        - composer require --dev phpunit/phpunit ~9.3 --ignore-platform-reqs
+#        - cd tests/PHPUnit
+#        - $PIWIK_ROOT_DIR/tests/travis/travis.sh
 
 dist: bionic
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,16 +51,6 @@ matrix:
         - composer require --dev phpunit/phpunit ~9.3 --ignore-platform-reqs
         - cd tests/PHPUnit
         - $PIWIK_ROOT_DIR/tests/travis/travis.sh
-# The minimum version of Matomo doesn't support PHP 8.1, so we're excluding it for now
-#    - php: 8.1
-#      env: TEST_SUITE=PluginTests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_CORE=minimum_required_piwik SKIP_COMPOSER_INSTALL=1
-#      script:
-#        - cd $PIWIK_ROOT_DIR
-#        - composer install --ignore-platform-reqs
-#        - composer remove --dev phpunit/phpunit
-#        - composer require --dev phpunit/phpunit ~9.3 --ignore-platform-reqs
-#        - cd tests/PHPUnit
-#        - $PIWIK_ROOT_DIR/tests/travis/travis.sh
 
 dist: bionic
 


### PR DESCRIPTION
### Description:

To try and reduce the number of Travis builds, we are removing PHP 7.4 from the builds so that we're only using PHP 7.2 and 8.1 for builds.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
