### PR TITLE
Add new command to block new organisations

### DIFF
--- a/Commands/BlockGeoIpOrganisation.php
+++ b/Commands/BlockGeoIpOrganisation.php
@@ -34,7 +34,10 @@ class BlockGeoIpOrganisation extends ConsoleCommand
         if (empty($pluginConfig[Configuration::KEY_GEOIP_MATCH_PROVIDERS])) {
             $pluginConfig[Configuration::KEY_GEOIP_MATCH_PROVIDERS] = [];
         }
-        $pluginConfig[Configuration::KEY_GEOIP_MATCH_PROVIDERS][] = mb_strtolower(trim($input->getOption('organisation-name')));
+
+        $name = $input->getOption('organisation-name');
+        $pluginConfig[Configuration::KEY_GEOIP_MATCH_PROVIDERS][] = mb_strtolower(trim($name));
+        
         $pluginConfig[Configuration::KEY_GEOIP_MATCH_PROVIDERS] = array_values(array_unique($pluginConfig[Configuration::KEY_GEOIP_MATCH_PROVIDERS]));
 
         $config->TrackingSpamPrevention = $pluginConfig;

--- a/Commands/BlockGeoIpOrganisation.php
+++ b/Commands/BlockGeoIpOrganisation.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\TrackingSpamPrevention\Commands;
+
+use Piwik\Plugin\ConsoleCommand;
+use Piwik\Config;
+use Piwik\Plugins\TrackingSpamPrevention\Configuration;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class BlockGeoIpOrganisation extends ConsoleCommand
+{
+    protected function configure()
+    {
+        $this->setName('trackingspamprevention:block-geo-ip-organisation');
+        $this->setDescription('Blocks a new GeoIP organisation. It will save the organisation in the config file.');
+        $this->addOption('organisation-name', null, InputOption::VALUE_REQUIRED, 'Name of the organisation to block:');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->checkAllRequiredOptionsAreNotEmpty($input);
+
+        $config = Config::getInstance();
+        $pluginConfig = $config->TrackingSpamPrevention;
+
+        if (empty($pluginConfig[Configuration::KEY_GEOIP_MATCH_PROVIDERS])) {
+            $pluginConfig[Configuration::KEY_GEOIP_MATCH_PROVIDERS] = [];
+        }
+        $pluginConfig[Configuration::KEY_GEOIP_MATCH_PROVIDERS][] = mb_strtolower(trim($input->getOption('organisation-name')));
+        $pluginConfig[Configuration::KEY_GEOIP_MATCH_PROVIDERS] = array_values(array_unique($pluginConfig[Configuration::KEY_GEOIP_MATCH_PROVIDERS]));
+
+        $config->TrackingSpamPrevention = $pluginConfig;
+        $config->forceSave();
+    }
+}

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -39,6 +39,12 @@ block_geoip_organisations[] = "ExampleOrg"
 block_geoip_organisations[] = "another example"
 ```
 
+Alternatively, you can execute a command to block a new organisation like this:
+
+```bash
+./console trackingspamprevention:block-geo-ip-organisation --organisation-name="Example"
+```
+
 Each organisation will be compared lower case and the organisation only needs to contain the configured value, it does not need to match it exactly.
 
 You can find out the organisation name for an IP address by visiting the website of your geolocation database and using their demo tool.


### PR DESCRIPTION
### Description:

I find myself blocking new organisations multiple times per week. Editing the config file to do this isn't such a nice experience and therefore figured it may be good to have a separate command for it. And instead of having this cloud specific figured it be good to make it available to others too. I was


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
