### PR TITLE
Adjusting the Azure download URL parsing to fix invalid URL error

### DIFF
--- a/BlockedIpRanges/Azure.php
+++ b/BlockedIpRanges/Azure.php
@@ -45,7 +45,7 @@ class Azure implements IpRangeProviderInterface
         return $ranges;
     }
 
-    private function getDownloadUrl()
+    public function getDownloadUrl()
     {
         //  get info somehow for up to date from url https://www.microsoft.com/en-us/download/confirmation.aspx?id=56519
 
@@ -60,7 +60,7 @@ class Azure implements IpRangeProviderInterface
         $prefixUrl = 'href="';
         $posStart = strpos($contentDownloadPage, $prefixUrl . 'https://download.microsoft.com/download/');
         $posEnd = strpos($contentDownloadPage, '.json"', $posStart + strlen($prefixUrl)); // we don't want to match the " in href="
-        $contentDownloadPage = Common::mb_substr($contentDownloadPage, $posStart - strlen($prefixUrl) + 2,
+        $contentDownloadPage = Common::mb_substr($contentDownloadPage, $posStart - strlen($prefixUrl) + 1,
           $posEnd - $posStart - strlen($prefixUrl));
         $downloadUrl = trim($contentDownloadPage, '="' . "'") . '.json';
         $downloadUrl = trim($downloadUrl);

--- a/tests/Integration/BlockedIpRanges/ProvidersTest.php
+++ b/tests/Integration/BlockedIpRanges/ProvidersTest.php
@@ -29,6 +29,13 @@ class ProvidersTest extends IntegrationTestCase
         $this->assertGreaterThan(5, count($ranges));
     }
 
+    public function test_getDownloadUrl_Azure()
+    {
+        $azure = new BlockedIpRanges\Azure();
+        $url = $azure->getDownloadUrl();
+        $this->assertStringStartsWith('https://download.microsoft.com/download/', $url);
+    }
+
     public function getIpRangeProviderDataProvider()
     {
         return [


### PR DESCRIPTION
### Description:

This fixes a parsing issue when determining the full Azure download URL.
Fixes: #85 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
