### PR TITLE
Include user agent in the banned IP email

### DIFF
--- a/BanIpNotificationEmail.php
+++ b/BanIpNotificationEmail.php
@@ -66,7 +66,11 @@ GET request info: ' . json_encode($get) . '
 POST request info: ' . json_encode($post). PHP_EOL;
 
         if (!empty($locationData)) {
-            $mailBody .= 'Geo IP info: ' . json_encode($locationData);
+            $mailBody .= 'Geo IP info: ' . json_encode($locationData) . PHP_EOL;
+        }
+
+        if (!empty($_SERVER['HTTP_USER_AGENT'])) {
+            $mailBody .= 'User Agent: ' . Common::sanitizeInputValue($_SERVER['HTTP_USER_AGENT']) . PHP_EOL;
         }
 
         $mail->setBodyText($mailBody);


### PR DESCRIPTION
We often receive these email notifications about a banned IP.  Sometimes we detect a hoster and block these. But sometimes it comes from a regular broadband provider and we can't really understand more about the request. Including the user agent to maybe learn more about the request and whether we can potentially ban / block this user agent in the future if it's not a regular browser.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
