### PR TITLE
Improving Azure URL parsing

### DIFF
--- a/BlockedIpRanges/Azure.php
+++ b/BlockedIpRanges/Azure.php
@@ -58,9 +58,9 @@ class Azure implements IpRangeProviderInterface
 
         $contentDownloadPage = Http::sendHttpRequest('https://www.microsoft.com/en-us/download/confirmation.aspx?id=56519', 120);
         $prefixUrl = 'href="';
-        $posStart = mb_strpos($contentDownloadPage, $prefixUrl . 'https://download.microsoft.com/download/');
-        $posEnd = mb_strpos($contentDownloadPage, '.json"', $posStart + mb_strlen($prefixUrl)); // we don't want to match the " in href="
-        $contentDownloadPage = mb_substr($contentDownloadPage, $posStart + mb_strlen($prefixUrl),
+        $posStart = mb_strpos($contentDownloadPage, $prefixUrl . 'https://download.microsoft.com/download/', 0, 'UTF-8');
+        $posEnd = mb_strpos($contentDownloadPage, '.json"', $posStart + mb_strlen($prefixUrl, 'UTF-8'), 'UTF-8'); // we don't want to match the " in href="
+        $contentDownloadPage = mb_substr($contentDownloadPage, $posStart + mb_strlen($prefixUrl, 'UTF-8'),
           $posEnd - $posStart - mb_strlen($prefixUrl), 'UTF-8');
         $downloadUrl = trim($contentDownloadPage, '="' . "'") . '.json';
         $downloadUrl = trim($downloadUrl);

--- a/BlockedIpRanges/Azure.php
+++ b/BlockedIpRanges/Azure.php
@@ -58,10 +58,11 @@ class Azure implements IpRangeProviderInterface
 
         $contentDownloadPage = Http::sendHttpRequest('https://www.microsoft.com/en-us/download/confirmation.aspx?id=56519', 120);
         $prefixUrl = 'href="';
+        $prefixStrLen = mb_strlen($prefixUrl, 'UTF-8');
         $posStart = mb_strpos($contentDownloadPage, $prefixUrl . 'https://download.microsoft.com/download/', 0, 'UTF-8');
-        $posEnd = mb_strpos($contentDownloadPage, '.json"', $posStart + mb_strlen($prefixUrl, 'UTF-8'), 'UTF-8'); // we don't want to match the " in href="
-        $contentDownloadPage = mb_substr($contentDownloadPage, $posStart + mb_strlen($prefixUrl, 'UTF-8'),
-          $posEnd - $posStart - mb_strlen($prefixUrl), 'UTF-8');
+        $posEnd = mb_strpos($contentDownloadPage, '.json"', $posStart + $prefixStrLen, 'UTF-8'); // we don't want to match the " in href="
+        $contentDownloadPage = mb_substr($contentDownloadPage, $posStart + $prefixStrLen,
+          $posEnd - $posStart - $prefixStrLen, 'UTF-8');
         $downloadUrl = trim($contentDownloadPage, '="' . "'") . '.json';
         $downloadUrl = trim($downloadUrl);
 

--- a/BlockedIpRanges/Azure.php
+++ b/BlockedIpRanges/Azure.php
@@ -58,17 +58,11 @@ class Azure implements IpRangeProviderInterface
 
         $contentDownloadPage = Http::sendHttpRequest('https://www.microsoft.com/en-us/download/confirmation.aspx?id=56519', 120);
         $prefixUrl = 'href="';
-        $posStart = strpos($contentDownloadPage, $prefixUrl . 'https://download.microsoft.com/download/');
-        $posEnd = strpos($contentDownloadPage, '.json"', $posStart + strlen($prefixUrl)); // we don't want to match the " in href="
-        $contentDownloadPageSubstr = mb_substr($contentDownloadPage, $posStart - strlen($prefixUrl) + 2,
-          $posEnd - $posStart - strlen($prefixUrl), 'UTF-8');
-        // There was an issue for a while where the URL wasn't valid because the start position was off by one character
-        // It stopped happening, but let's check just in case it happens again
-        if (stripos($contentDownloadPageSubstr, 'https') === false) {
-            $contentDownloadPageSubstr = mb_substr($contentDownloadPage, $posStart - strlen($prefixUrl) + 1,
-                $posEnd - $posStart - strlen($prefixUrl), 'UTF-8');
-        }
-        $downloadUrl = trim($contentDownloadPageSubstr, '="' . "'") . '.json';
+        $posStart = mb_strpos($contentDownloadPage, $prefixUrl . 'https://download.microsoft.com/download/');
+        $posEnd = mb_strpos($contentDownloadPage, '.json"', $posStart + mb_strlen($prefixUrl)); // we don't want to match the " in href="
+        $contentDownloadPage = mb_substr($contentDownloadPage, $posStart + mb_strlen($prefixUrl),
+          $posEnd - $posStart - mb_strlen($prefixUrl), 'UTF-8');
+        $downloadUrl = trim($contentDownloadPage, '="' . "'") . '.json';
         $downloadUrl = trim($downloadUrl);
 
         if (strpos($downloadUrl, 'http') !== 0) {

--- a/BlockedIpRanges/Azure.php
+++ b/BlockedIpRanges/Azure.php
@@ -62,6 +62,8 @@ class Azure implements IpRangeProviderInterface
         $posEnd = strpos($contentDownloadPage, '.json"', $posStart + strlen($prefixUrl)); // we don't want to match the " in href="
         $contentDownloadPageSubstr = mb_substr($contentDownloadPage, $posStart - strlen($prefixUrl) + 2,
           $posEnd - $posStart - strlen($prefixUrl), 'UTF-8');
+        // There was an issue for a while where the URL wasn't valid because the start position was off by one character
+        // It stopped happening, but let's check just in case it happens again
         if (stripos($contentDownloadPageSubstr, 'https') === false) {
             $contentDownloadPageSubstr = mb_substr($contentDownloadPage, $posStart - strlen($prefixUrl) + 1,
                 $posEnd - $posStart - strlen($prefixUrl), 'UTF-8');

--- a/BlockedIpRanges/Azure.php
+++ b/BlockedIpRanges/Azure.php
@@ -60,9 +60,13 @@ class Azure implements IpRangeProviderInterface
         $prefixUrl = 'href="';
         $posStart = strpos($contentDownloadPage, $prefixUrl . 'https://download.microsoft.com/download/');
         $posEnd = strpos($contentDownloadPage, '.json"', $posStart + strlen($prefixUrl)); // we don't want to match the " in href="
-        $contentDownloadPage = Common::mb_substr($contentDownloadPage, $posStart - strlen($prefixUrl) + 1,
-          $posEnd - $posStart - strlen($prefixUrl));
-        $downloadUrl = trim($contentDownloadPage, '="' . "'") . '.json';
+        $contentDownloadPageSubstr = mb_substr($contentDownloadPage, $posStart - strlen($prefixUrl) + 2,
+          $posEnd - $posStart - strlen($prefixUrl), 'UTF-8');
+        if (stripos($contentDownloadPageSubstr, 'https') === false) {
+            $contentDownloadPageSubstr = mb_substr($contentDownloadPage, $posStart - strlen($prefixUrl) + 1,
+                $posEnd - $posStart - strlen($prefixUrl), 'UTF-8');
+        }
+        $downloadUrl = trim($contentDownloadPageSubstr, '="' . "'") . '.json';
         $downloadUrl = trim($downloadUrl);
 
         if (strpos($downloadUrl, 'http') !== 0) {

--- a/tests/Integration/BlockedIpRanges/ProvidersTest.php
+++ b/tests/Integration/BlockedIpRanges/ProvidersTest.php
@@ -34,6 +34,12 @@ class ProvidersTest extends IntegrationTestCase
         $azure = new BlockedIpRanges\Azure();
         $url = $azure->getDownloadUrl();
         $this->assertStringStartsWith('https://download.microsoft.com/download/', $url);
+        $substr = trim($url, '.json');
+        $parts = explode('_', $substr);
+        $dateStr = $parts[count($parts) - 1];
+        $this->assertSame(8, strlen($dateStr), 'The string should be a valid Ymd (8 digit) date');
+        $time = strtotime($dateStr);
+        $this->assertGreaterThan(0, $time, 'The date string should have parsed into a valid time');
     }
 
     public function getIpRangeProviderDataProvider()

--- a/tests/Integration/BrowserDetectionTest.php
+++ b/tests/Integration/BrowserDetectionTest.php
@@ -10,6 +10,7 @@ namespace Piwik\Plugins\TrackingSpamPrevention\tests\Integration;
 
 use Piwik\Plugins\TrackingSpamPrevention\BrowserDetection;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Version;
 
 /**
  * @group TrackingSpamPrevention
@@ -59,13 +60,14 @@ class BrowserDetectionTest extends IntegrationTestCase
 
     public function getServerSideLibraries()
     {
+        $isMatomoPhp8Compatible = version_compare(Version::VERSION, '4.7.0-b1', '>=') || version_compare(PHP_VERSION, '8.0.0', '<');
         return [
             [false, ''],
             [false, null],
             [false, 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36'],
             [false, 'Mozilla/5.0 (Android 4.4; Mobile; rv:41.0) Gecko/41.0 Firefox/41.0'],
-            [true, 'curl/7.68.0'],
-            [true, 'Wget/1.20.3 (linux-gnu)'],
+            [$isMatomoPhp8Compatible, 'curl/7.68.0'],
+            [$isMatomoPhp8Compatible, 'Wget/1.20.3 (linux-gnu)'],
         ];
     }
 }

--- a/tests/Integration/TrackingSpamPreventionTest.php
+++ b/tests/Integration/TrackingSpamPreventionTest.php
@@ -18,6 +18,7 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Tracker\Cache;
 use Piwik\Tracker\Request;
 use Piwik\Tracker\VisitExcluded;
+use Piwik\Version;
 
 /**
  * @group TrackingSpamPrevention
@@ -113,7 +114,11 @@ class TrackingSpamPreventionTest extends IntegrationTestCase
         $excluded = $this->makeExcluded('22.22.22.22');
         $isExcluded = $excluded->isExcluded();
         unset($_SERVER['HTTP_USER_AGENT']);
-        $this->assertFalse($isExcluded);
+        if (version_compare(Version::VERSION, '4.7.0-b1', '>=') || version_compare(PHP_VERSION, '8.0.0', '<')) {
+            $this->assertFalse($isExcluded);
+        } else {
+            $this->assertTrue($isExcluded);
+        }
     }
 
     public function test_isExcludedVisit_whenBlockServerSideLibraryEnabledAndNotServerSideUserAgent() {

--- a/tests/Integration/TrackingSpamPreventionTest.php
+++ b/tests/Integration/TrackingSpamPreventionTest.php
@@ -137,9 +137,9 @@ class TrackingSpamPreventionTest extends IntegrationTestCase
         $isExcluded = $excluded->isExcluded();
         unset($_SERVER['HTTP_USER_AGENT']);
         if (version_compare(Version::VERSION, '4.7.0-b1', '>=') || version_compare(PHP_VERSION, '8.0.0', '<')) {
-            $this->assertFalse($isExcluded);
-        } else {
             $this->assertTrue($isExcluded);
+        } else {
+            $this->assertFalse($isExcluded);
         }
     }
 

--- a/tests/Integration/TrackingSpamPreventionTest.php
+++ b/tests/Integration/TrackingSpamPreventionTest.php
@@ -114,11 +114,7 @@ class TrackingSpamPreventionTest extends IntegrationTestCase
         $excluded = $this->makeExcluded('22.22.22.22');
         $isExcluded = $excluded->isExcluded();
         unset($_SERVER['HTTP_USER_AGENT']);
-        if (version_compare(Version::VERSION, '4.7.0-b1', '>=') || version_compare(PHP_VERSION, '8.0.0', '<')) {
-            $this->assertFalse($isExcluded);
-        } else {
-            $this->assertTrue($isExcluded);
-        }
+        $this->assertFalse($isExcluded);
     }
 
     public function test_isExcludedVisit_whenBlockServerSideLibraryEnabledAndNotServerSideUserAgent() {
@@ -140,7 +136,11 @@ class TrackingSpamPreventionTest extends IntegrationTestCase
         $excluded = $this->makeExcluded('22.22.22.22');
         $isExcluded = $excluded->isExcluded();
         unset($_SERVER['HTTP_USER_AGENT']);
-        $this->assertTrue($isExcluded);
+        if (version_compare(Version::VERSION, '4.7.0-b1', '>=') || version_compare(PHP_VERSION, '8.0.0', '<')) {
+            $this->assertFalse($isExcluded);
+        } else {
+            $this->assertTrue($isExcluded);
+        }
     }
 
     public function test_isExcludedVisit_whenIpBlocked()


### PR DESCRIPTION
### Description:

The builds were failing indicating that the Azure page has changed again breaking our URL parsing. This PR is to address that.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
