### PR TITLE
Make the max action limit ignore allow list of IP addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+# 5.0.1
+- Fix issue where max action limit was blocking IP addresses from the allow list
+
 # 5.0.0
 - Compatibility with Matomo 5.0
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "TrackingSpamPrevention",
     "description": "This plugin offers various options to prevent spammers and bots from making your data inaccurate so you can rely on your data again.",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "theme": false,
     "require": {
         "matomo": ">=5.0.0-b1,<6.0.0-b1"

--- a/tests/Integration/Tracker/RequestProcessorTest.php
+++ b/tests/Integration/Tracker/RequestProcessorTest.php
@@ -88,6 +88,17 @@ class RequestProcessorTest extends IntegrationTestCase
         $this->assertSame([], $this->ranges->getBlockedRanges());
     }
 
+    public function test_updateBlockedIpRanges_maxActionsEnabled_limitReached_shouldIgnoreAllowedIpHigherActions()
+    {
+        Config::getInstance()->TrackingSpamPrevention = [
+            Configuration::KEY_RANGE_ALLOW_LIST => ['10.12.13.14/32', 'f::f/52', '', '11.12.13.14/21', '12.14.15.16', 'f::f']
+        ];
+        $this->settings->max_actions->setValue(200);
+
+        $this->assertNull($this->processor->afterRequestProcessed($this->makeVisit(800), $this->makeRequest()));
+        $this->assertSame([], $this->ranges->getBlockedRanges());
+    }
+
     private function makeVisit($actions)
     {
         $visit = new VisitProperties();

--- a/tests/Integration/Tracker/RequestProcessorTest.php
+++ b/tests/Integration/Tracker/RequestProcessorTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Plugins\TrackingSpamPrevention\tests\Integration\Tracker;
 
+use Piwik\Config;
 use Piwik\Plugins\TrackingSpamPrevention\BlockedIpRanges;
 use Piwik\Plugins\TrackingSpamPrevention\Configuration;
 use Piwik\Plugins\TrackingSpamPrevention\SystemSettings;
@@ -74,6 +75,17 @@ class RequestProcessorTest extends IntegrationTestCase
 
         $this->assertTrue($this->processor->afterRequestProcessed($this->makeVisit(200), $this->makeRequest()));
         $this->assertSame(['11.' => ['11.12.13.14/32']], $this->ranges->getBlockedRanges());
+    }
+
+    public function test_updateBlockedIpRanges_maxActionsEnabled_limitReached_shouldIgnoreAllowedIp()
+    {
+        Config::getInstance()->TrackingSpamPrevention = [
+            Configuration::KEY_RANGE_ALLOW_LIST => ['10.12.13.14/32', 'f::f/52', '', '11.12.13.14/21', '12.14.15.16', 'f::f']
+        ];
+        $this->settings->max_actions->setValue(200);
+
+        $this->assertNull($this->processor->afterRequestProcessed($this->makeVisit(200), $this->makeRequest()));
+        $this->assertSame([], $this->ranges->getBlockedRanges());
     }
 
     private function makeVisit($actions)


### PR DESCRIPTION
### Description:

The max action limit was blocking IP addresses on the always allow list. This is to fix that.
Jira Issue: PG-3333

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
