### PR TITLE
Look for headless browser in clientHint, #PG-3304

### DIFF
--- a/TrackingSpamPrevention.php
+++ b/TrackingSpamPrevention.php
@@ -96,9 +96,13 @@ class TrackingSpamPrevention extends \Piwik\Plugin
         $browserLang = $request->getBrowserLanguage();
 
         $browserDetection = new BrowserDetection();
+        $clientHints = json_encode($request->getClientHints());
         if (
-            $settings->blockHeadless->getValue()
-            && $browserDetection->isHeadlessBrowser($request->getUserAgent())
+            $settings->blockHeadless->getValue() &&
+            (
+                $browserDetection->isHeadlessBrowser($request->getUserAgent()) ||
+                $browserDetection->isHeadlessBrowser($clientHints)
+            )
         ) {
             // note above user agent could have been overwritten with UA parameter but that's fine since it's easy to change useragent anyway
             Common::printDebug("Excluding visit as headless browser detected");

--- a/tests/Integration/TrackingSpamPreventionTest.php
+++ b/tests/Integration/TrackingSpamPreventionTest.php
@@ -77,6 +77,20 @@ class TrackingSpamPreventionTest extends IntegrationTestCase
         $this->assertTrue($isExcluded);
     }
 
+    public function test_isExcludedVisit_whenHeadlessClientHint()
+    {
+        StaticContainer::get(SystemSettings::class)->blockHeadless->setValue(1);
+        Cache::clearCacheGeneral();
+
+        // set normal browser not a headless browser
+        $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.0 Safari/537.36';
+        $excluded = $this->makeExcluded('22.22.22.22');
+        $excluded->request->setParam('uadata', '{"fullVersionList":[{"brand":"Not A(Brand","version":"99.0.0.0"},{"brand":"HeadlessChrome","version":"121.0.6167.57"},{"brand":"Chromium","version":"121.0.6167.57"}],"mobile":false,"model":"","platform":"Linux","platformVersion":"5.15.0"}');
+        $isExcluded = $excluded->isExcluded();
+        unset($_SERVER['HTTP_USER_AGENT']);
+        $this->assertTrue($isExcluded);
+    }
+
     public function test_isExcludedVisit_whenBlockedUserAgentDisabled()
     {
         StaticContainer::get(SystemSettings::class)->blockHeadless->setValue(0);


### PR DESCRIPTION
### Description:

Look for headless browser in clientHint
Fixes: #PG-3304, #108

To test this, you can execute the below curl call
```
curl -X POST "http://localhost.matomo.com/matomo.php?action_name=Welcome&idsite=3&rec=1&r=577211&h=9&m=53&s=13&url=https%3A%2F%2Fwww.example.com%2Fen%2F&_id=&_idn=1&send_image=0&_refts=0&cookie=1&res=1280x720&dimension4=en&dimension8=content&pv_id=8jAVo2&pf_net=500&pf_srv=747&pf_tfr=366&uadata=%7B%22fullVersionList%22%3A%5B%7B%22brand%22%3A%22Not%20A(Brand%22%2C%22version%22%3A%2299.0.0.0%22%7D%2C%7B%22brand%22%3A%22HeadlessChrome%22%2C%22version%22%3A%22121.0.6167.57%22%7D%2C%7B%22brand%22%3A%22Chromium%22%2C%22version%22%3A%22121.0.6167.57%22%7D%5D%2C%22mobile%22%3Afalse%2C%22model%22%3A%22%22%2C%22platform%22%3A%22Linux%22%2C%22platformVersion%22%3A%225.15.0%22%7D" -k
```

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
