### PR TITLE
Adding Matomo URL to email report

### DIFF
--- a/BanIpNotificationEmail.php
+++ b/BanIpNotificationEmail.php
@@ -36,10 +36,15 @@ class BanIpNotificationEmail
             $mail->setFrom($mail->getFrom(), 'Web Analytics Reports');
         }
 
+
         $mailBody = 'This is for your information. The following IP was banned because visit tried to track more than ' . Common::sanitizeInputValue($maxActionsAllowed) . ' actions:';
         $mailBody .= PHP_EOL . PHP_EOL . '"' . Common::sanitizeInputValue($ipRange) . '"' . PHP_EOL;
         $instanceId = SettingsPiwik::getPiwikInstanceId();
-
+        $matomoUrl = SettingsPiwik::getPiwikUrl();
+        if (!empty($matomoUrl)) {
+            $url = parse_url($matomoUrl);
+            $matomoHost = $url['host'];
+        }
 
         if (!empty($_GET)) {
             $get = $_GET;
@@ -61,6 +66,9 @@ class BanIpNotificationEmail
 
         if (!empty($instanceId)) {
             $mailBody .= PHP_EOL . 'Instance ID: ' . Common::sanitizeInputValue($instanceId);
+        }
+        if (!empty($matomoHost)) {
+            $mailBody .= PHP_EOL . 'URL: ' . Common::sanitizeInputValue($matomoHost);
         }
         $mailBody .= PHP_EOL . 'Current date (UTC): ' . Common::sanitizeInputValue($nowDateTime) . '
 IP as detected in header: ' . Common::sanitizeInputValue($ip) . '

--- a/tests/Integration/NotificationEmailTest.php
+++ b/tests/Integration/NotificationEmailTest.php
@@ -43,6 +43,7 @@ class NotificationEmailTest extends IntegrationTestCase
 
 "10.10.10.10/12"
 
+URL: localhost
 Current date (UTC): 2020-12-14 01:42:27
 IP as detected in header: 127.0.0.1
 GET request info: []


### PR DESCRIPTION
### Description:

When you manage more than one Matomo instance, you would like to know from which instance you are getting email alert. This merge requests adds Matomo URL to the email report.

Fixes: #136

### Review

* [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
