### PR TITLE
Fixes azure download link broken due to DOM changes at Microsoft end

### DIFF
--- a/BlockedIpRanges/Azure.php
+++ b/BlockedIpRanges/Azure.php
@@ -58,7 +58,7 @@ class Azure implements IpRangeProviderInterface
         // should look like 'https://download.microsoft.com/download/7/1/D/71D86715-5596-4529-9B13-DA13A5DE5B63/ServiceTags_Public_20201207.json'
 
         $contentDownloadPage = Http::sendHttpRequest('https://www.microsoft.com/en-us/download/details.aspx?id=56519', 120);
-        $prefixUrl = 'href="';
+        $prefixUrl = 'url":"';
         $prefixStrLen = mb_strlen($prefixUrl, 'UTF-8');
         $posStart = mb_strpos($contentDownloadPage, $prefixUrl . 'https://download.microsoft.com/download/', 0, 'UTF-8');
         $posEnd = mb_strpos($contentDownloadPage, '.json"', $posStart + $prefixStrLen, 'UTF-8'); // we don't want to match the " in href="

--- a/BlockedIpRanges/Azure.php
+++ b/BlockedIpRanges/Azure.php
@@ -61,7 +61,7 @@ class Azure implements IpRangeProviderInterface
         $prefixUrl = 'url":"';
         $prefixStrLen = mb_strlen($prefixUrl, 'UTF-8');
         $posStart = mb_strpos($contentDownloadPage, $prefixUrl . 'https://download.microsoft.com/download/', 0, 'UTF-8');
-        $posEnd = mb_strpos($contentDownloadPage, '.json"', $posStart + $prefixStrLen, 'UTF-8'); // we don't want to match the " in href="
+        $posEnd = mb_strpos($contentDownloadPage, '.json"', $posStart + $prefixStrLen, 'UTF-8'); // we don't want to match the " in url":"
         $contentDownloadPage = mb_substr(
             $contentDownloadPage,
             $posStart + $prefixStrLen,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+# 5.0.8 - 2025-05-26
+- Fixed broken Azure link for looking up IP ranges
+
 # 5.0.7 - 2025-01-06
 - Added Matomo URL to email report
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "TrackingSpamPrevention",
     "description": "This plugin offers various options to prevent spammers and bots from making your data inaccurate so you can rely on your data again.",
-    "version": "5.0.7",
+    "version": "5.0.8",
     "theme": false,
     "require": {
         "matomo": ">=5.0.0-b1,<6.0.0-b1"


### PR DESCRIPTION
## Description
We download the Azure IP ranges, by doing below steps:
1. Get the contents of a URL where Azure I/P ranges download action is present
2. Find the download link using substr manipulation

The step2 was broken as the DOM was changed and we were unable to determine the download URL.

## Issue No
Raised on Slack by core-team as their automated release was not working due to this plugin being added as a submodule and the Azure download URL test was failing.

## Steps to Replicate the Issue
1. Run this test and it will fail for Azure
```
./console tests:run plugins/TrackingSpamPrevention/tests/Integration/BlockedIpRanges/ProvidersTest.php --filter="test_getRanges"
```
2. Checkout this PR and run the same test and it should work fine.



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?