### PR TITLE
Adds code to enable headless browser by default for new instances, #PG-5306

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+# 5.0.10 - 2026-07-06
+- Enabled block headless browser by default
+
 # 5.0.10 - 2026-06-22
 - Removed Verein zur Foerderung eines Deutschen Forschungsnetzes (DFN) from the default block list
 

--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -72,7 +72,7 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
 
     private function createBlockHeadlessSettings()
     {
-        return $this->makeSetting('block_headless', $default = false, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
+        return $this->makeSetting('block_headless', $default = true, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
             $field->title = Piwik::translate('TrackingSpamPrevention_SettingBlockHeadlessTitle');
             $field->description = Piwik::translate('TrackingSpamPrevention_SettingBlockHeadlessDescription');
             $field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;

--- a/Updates/5.0.11.php
+++ b/Updates/5.0.11.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\TrackingSpamPrevention;
+
+use Piwik\Config;
+use Piwik\Settings\Storage\Factory;
+use Piwik\Updater;
+use Piwik\Updates as PiwikUpdates;
+
+class Updates_5_0_11 extends PiwikUpdates
+{
+    public function doUpdate(Updater $updater)
+    {
+        $pluginConfig = Config::getInstance()->TrackingSpamPrevention;
+
+        if (is_array($pluginConfig) && array_key_exists('block_headless', $pluginConfig)) {
+            return;
+        }
+
+        $backend = (new Factory())->getPluginStorage('TrackingSpamPrevention', '')->getBackend();
+        $currentValue = $backend->loadValue('block_headless', null);
+
+        if ($currentValue !== null) {
+            return;
+        }
+
+        $backend->saveValue('block_headless', false);
+    }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "TrackingSpamPrevention",
     "description": "This plugin offers various options to prevent spammers and bots from making your data inaccurate so you can rely on your data again.",
-    "version": "5.0.10",
+    "version": "5.0.11",
     "theme": false,
     "require": {
         "matomo": ">=5.0.0-b1,<6.0.0-b1"

--- a/tests/Integration/SystemSettingsTest.php
+++ b/tests/Integration/SystemSettingsTest.php
@@ -52,13 +52,13 @@ class SystemSettingsTest extends IntegrationTestCase
 
     public function test_block_headless_default()
     {
-        $this->assertSame(false, $this->settings->blockHeadless->getValue());
+        $this->assertSame(true, $this->settings->blockHeadless->getValue());
     }
 
-    public function test_block_Headless_enable()
+    public function test_block_Headless_disable()
     {
-        $this->settings->blockHeadless->setValue(1);
-        $this->assertSame(true, $this->settings->blockHeadless->getValue());
+        $this->settings->blockHeadless->setValue(0);
+        $this->assertSame(false, $this->settings->blockHeadless->getValue());
     }
 
     public function test_notification_email_default()

--- a/tests/UI/expected-screenshots/TrackingSpamPreventionSettings_page.png
+++ b/tests/UI/expected-screenshots/TrackingSpamPreventionSettings_page.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1b99b585e14aba21c14f166b109991aec5960a68780e758ec013eb4ab78c7562
-size 165015
+oid sha256:d07cd24a78dc5c01d7034e89bbf0bf40f3b46fc054191a6ea6118691b17e7557
+size 165455


### PR DESCRIPTION
## Description
Adds code to enable headless browser by default for new instances

## Issue No
#PG-5306

## Steps to Replicate the Issue
1. Block headless should be disabled by default for new instances



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
