### PR TITLE
Update expected UI screenshots for the new headless Chrome (Node 24 / Puppeteer 24)

### DIFF
--- a/.github/workflows/matomo-tests.yml
+++ b/.github/workflows/matomo-tests.yml
@@ -76,6 +76,6 @@ jobs:
           mysql-engine: 'Mysql'
           mysql-version: '8.0'
           php-version: '8.1'
-          node-version: '16'
+          node-version: '24'
           artifacts-pass: ${{ secrets.ARTIFACTS_PASS }}
           upload-artifacts: true

--- a/tests/UI/expected-screenshots/TrackingSpamPreventionSettings_page.png
+++ b/tests/UI/expected-screenshots/TrackingSpamPreventionSettings_page.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d07cd24a78dc5c01d7034e89bbf0bf40f3b46fc054191a6ea6118691b17e7557
-size 165455
+oid sha256:0278c7f28e145680fee27bb211e810d25125004a4658c3969a1c4eecf4859cb5
+size 342

--- a/tests/UI/expected-screenshots/TrackingSpamPreventionSettings_page.png
+++ b/tests/UI/expected-screenshots/TrackingSpamPreventionSettings_page.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0278c7f28e145680fee27bb211e810d25125004a4658c3969a1c4eecf4859cb5
-size 342
+oid sha256:1303d2967a0199a562198b725ae044af564eb727ce9578abfb03748a95d8d7ae
+size 153030


### PR DESCRIPTION
Updates the expected UI test screenshots for the new headless Chrome used by the modernized screenshot-testing harness (Node 24 / Puppeteer 24).

This is the submodule counterpart of the core migration PR and must be merged together with it:
matomo-org/matomo#24677

The screenshot changes are rendering drift from the new headless Chrome (identical content, minor line-height/anti-aliasing shifts); each was reviewed against the previous expected before syncing.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
