### PR TITLE
Add IP allow list setting to the UI, PG-3570

### DIFF
--- a/AllowListIpRange.php
+++ b/AllowListIpRange.php
@@ -14,18 +14,18 @@ use Matomo\Network\IP;
 class AllowListIpRange
 {
     /**
-     * @var Configuration
+     * @var SystemSettings
      */
-    private $configuration;
+    private $settings;
 
-    public function __construct(Configuration $configuration)
+    public function __construct(SystemSettings $settings)
     {
-        $this->configuration = $configuration;
+        $this->settings = $settings;
     }
 
     public function isAllowed($ip)
     {
-        $rangesAllowed = $this->configuration->getIpRangesAlwaysAllowed();
+        $rangesAllowed = $this->settings->getAllowedIpRanges();
 
         if (!empty($rangesAllowed)) {
             $ip  = IP::fromStringIP($ip);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 # 5.1.0 - 2026-08-03
 - Added an "IP allow list" setting to the UI (General Settings). Existing `iprange_allowlist` config values are migrated to the new `ip_allow_list` system setting and removed from the config file
-- Deprecated `Configuration::getIpRangesAlwaysAllowed()`, use `SystemSettings::getAllowedIpRanges()` instead
-- `AllowListIpRange` now expects a `SystemSettings` instance in its constructor instead of a `Configuration` instance
 
 # 5.0.11 - 2026-07-06
 - Enabled block headless browser by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+# 5.1.0
+- Added an "IP allow list" setting to the UI (General Settings). Existing `iprange_allowlist` config values are migrated to the new `ip_allow_list` system setting and removed from the config file
+- Deprecated `Configuration::getIpRangesAlwaysAllowed()`, use `SystemSettings::getAllowedIpRanges()` instead
+- `AllowListIpRange` now expects a `SystemSettings` instance in its constructor instead of a `Configuration` instance
+
 # 5.0.11 - 2026-07-06
 - Enabled block headless browser by default
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-# 5.1.0
+# 5.1.0 - 2026-08-03
 - Added an "IP allow list" setting to the UI (General Settings). Existing `iprange_allowlist` config values are migrated to the new `ip_allow_list` system setting and removed from the config file
 - Deprecated `Configuration::getIpRangesAlwaysAllowed()`, use `SystemSettings::getAllowedIpRanges()` instead
 - `AllowListIpRange` now expects a `SystemSettings` instance in its constructor instead of a `Configuration` instance

--- a/Configuration.php
+++ b/Configuration.php
@@ -10,10 +10,13 @@
 namespace Piwik\Plugins\TrackingSpamPrevention;
 
 use Piwik\Config;
+use Piwik\Container\StaticContainer;
 
 class Configuration
 {
     public const DEFAULT_RANGE_THROW_EXCEPTION = 0;
+
+    /** @deprecated since 5.1.0, the allow list was moved to the `ip_allow_list` system setting */
     public const DEFAULT_RANGE_ALLOW_LIST = [''];
     public const DEFAULT_GEOIP_MATCH_PROVIDERS = [
         'alicloud',
@@ -89,6 +92,8 @@ class Configuration
     ];
 
     public const KEY_RANGE_THROW_EXCEPTION = 'block_cloud_sync_throw_exception_on_error';
+
+    /** @deprecated since 5.1.0, the allow list was moved to the `ip_allow_list` system setting */
     public const KEY_RANGE_ALLOW_LIST = 'iprange_allowlist';
     public const KEY_GEOIP_MATCH_PROVIDERS = 'block_geoip_organisations';
 
@@ -103,9 +108,6 @@ class Configuration
 
         if (empty($default[self::KEY_RANGE_THROW_EXCEPTION])) {
             $default[self::KEY_RANGE_THROW_EXCEPTION] = self::DEFAULT_RANGE_THROW_EXCEPTION;
-        }
-        if (empty($default[self::KEY_RANGE_ALLOW_LIST])) {
-            $default[self::KEY_RANGE_ALLOW_LIST] = self::DEFAULT_RANGE_ALLOW_LIST;
         }
         if (empty($default[self::KEY_GEOIP_MATCH_PROVIDERS])) {
             $default[self::KEY_GEOIP_MATCH_PROVIDERS] = self::DEFAULT_GEOIP_MATCH_PROVIDERS;
@@ -138,30 +140,13 @@ class Configuration
     }
 
     /**
+     * @deprecated since 5.1.0, use SystemSettings::getAllowedIpRanges() instead. The allow list was moved from the
+     *             config file to the `ip_allow_list` system setting.
      * @return array
      */
     public function getIpRangesAlwaysAllowed()
     {
-        $value = $this->getConfigValue(self::KEY_RANGE_ALLOW_LIST, self::DEFAULT_RANGE_ALLOW_LIST);
-
-        if (empty($value) || !is_array($value)) {
-            $value = self::DEFAULT_RANGE_ALLOW_LIST;
-        }
-
-        $value = array_values(array_filter($value));
-        $value = array_map(function ($range) {
-            if (strpos($range, '/') === false) {
-                // we assume user did not enter a range so we make it one that matches that one ip
-                if (strpos($range, '.') !== false) {
-                    $range .= '/32';
-                } elseif (strpos($range, ':') !== false) {
-                    $range .= '/128';
-                }
-            }
-            return $range;
-        }, $value);
-
-        return $value;
+        return StaticContainer::get(SystemSettings::class)->getAllowedIpRanges();
     }
 
     private function getConfig()

--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -18,6 +18,7 @@ use Piwik\Settings\FieldConfig;
 use Piwik\SettingsPiwik;
 use Piwik\Tracker\Cache;
 use Piwik\Validators\Email;
+use Piwik\Validators\IpRanges;
 
 class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
 {
@@ -42,6 +43,9 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     /** @var Setting */
     public $blockServerSideLibraries;
 
+    /** @var Setting */
+    public $ipAllowList;
+
     protected function init()
     {
         $this->block_clouds = $this->createBlockCloudsSetting();
@@ -52,6 +56,12 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
 
         $this->excludedCountries = $this->createExcludedCountriesSetting();
         $this->includedCountries = $this->createIncludedCountriesSetting();
+
+        $this->ipAllowList = $this->makeIpRangeListSetting(
+            'ip_allow_list',
+            'TrackingSpamPrevention_SettingIpAllowListTitle',
+            'TrackingSpamPrevention_SettingIpAllowListHelp'
+        );
     }
 
     private function createBlockCloudsSetting()
@@ -203,6 +213,25 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     }
 
 
+    private function makeIpRangeListSetting(string $name, string $titleKey, string $inlineHelpKey): Setting
+    {
+        return $this->makeSetting($name, [], FieldConfig::TYPE_ARRAY, function (FieldConfig $field) use ($titleKey, $inlineHelpKey) {
+            $field->title = Piwik::translate($titleKey);
+            $field->inlineHelp = Piwik::translate($inlineHelpKey);
+            $field->uiControl = FieldConfig::UI_CONTROL_TEXTAREA;
+            $field->uiControlAttributes['placeholder'] = "192.0.2.15\n198.51.100.0/24\n2001:db8::/32";
+            $field->validators[] = new IpRanges();
+            $field->transform = function ($value) {
+                if (empty($value) || !is_array($value)) {
+                    return [];
+                }
+                $ips = array_map('trim', $value);
+                $ips = array_filter($ips, 'strlen');
+                return array_values(array_unique($ips));
+            };
+        });
+    }
+
     private function listCountries()
     {
         $regionDataProvider = StaticContainer::get(RegionDataProvider::class);
@@ -212,6 +241,18 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         });
         asort($countryList); //order by localized name
         return $countryList;
+    }
+
+    public function getAllowedIpRanges(): array
+    {
+        $value = $this->ipAllowList->getValue();
+
+        if (empty($value) || !is_array($value)) {
+            return [];
+        }
+
+        // values set through a config file override skip the setting's transform, so clean them up here too
+        return array_values(array_filter(array_map('trim', $value), 'strlen'));
     }
 
     public function getExcludedCountryCodes()

--- a/Updates/5.1.0.php
+++ b/Updates/5.1.0.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\TrackingSpamPrevention;
+
+use Piwik\Config;
+use Piwik\Settings\Storage\Backend\Cache;
+use Piwik\Settings\Storage\Factory;
+use Piwik\Updater;
+use Piwik\Updates as PiwikUpdates;
+use Piwik\Validators\IpRanges;
+
+/**
+ * Migrates the `iprange_allowlist` config value to the `ip_allow_list` system setting.
+ */
+class Updates_5_1_0 extends PiwikUpdates
+{
+    public function doUpdate(Updater $updater)
+    {
+        $config = Config::getInstance();
+        $pluginConfig = $config->TrackingSpamPrevention;
+
+        if (!is_array($pluginConfig) || !array_key_exists(Configuration::KEY_RANGE_ALLOW_LIST, $pluginConfig)) {
+            return;
+        }
+
+        $ranges = $this->getValidRanges($pluginConfig[Configuration::KEY_RANGE_ALLOW_LIST]);
+
+        if (!empty($ranges)) {
+            $backend = (new Factory())->getPluginStorage('TrackingSpamPrevention', '')->getBackend();
+
+            if (empty($backend->loadValue('ip_allow_list'))) {
+                $backend->saveValue('ip_allow_list', $ranges);
+                Cache::clearCache();
+            }
+        }
+
+        unset($pluginConfig[Configuration::KEY_RANGE_ALLOW_LIST]);
+        $config->TrackingSpamPrevention = $pluginConfig;
+
+        try {
+            $config->forceSave();
+        } catch (\Exception $e) {
+            // the config file might not be writable, the leftover key is no longer read anywhere
+        }
+    }
+
+    private function getValidRanges($configRanges): array
+    {
+        if (!is_array($configRanges)) {
+            return [];
+        }
+
+        $validator = new IpRanges();
+
+        $ranges = [];
+        foreach ($configRanges as $range) {
+            $range = trim((string) $range);
+            if ($range === '') {
+                continue;
+            }
+            try {
+                $validator->validate([$range]);
+                $ranges[] = $range;
+            } catch (\Exception $e) {
+                // drop invalid entries, they never matched any request anyway
+            }
+        }
+
+        return array_values(array_unique($ranges));
+    }
+}

--- a/Updates/5.1.0.php
+++ b/Updates/5.1.0.php
@@ -33,6 +33,8 @@ class Updates_5_1_0 extends PiwikUpdates
 
         if (!empty($ranges)) {
             $settings = StaticContainer::get(SystemSettings::class);
+            // updates run as super user, but the setting also reports as unwritable when an `ip_allow_list`
+            // config override already exists, so force writability to keep the migration from failing
             $settings->ipAllowList->setIsWritableByCurrentUser(true);
 
             if (empty($settings->ipAllowList->getValue())) {

--- a/Updates/5.1.0.php
+++ b/Updates/5.1.0.php
@@ -10,8 +10,7 @@
 namespace Piwik\Plugins\TrackingSpamPrevention;
 
 use Piwik\Config;
-use Piwik\Settings\Storage\Backend\Cache;
-use Piwik\Settings\Storage\Factory;
+use Piwik\Container\StaticContainer;
 use Piwik\Updater;
 use Piwik\Updates as PiwikUpdates;
 use Piwik\Validators\IpRanges;
@@ -33,11 +32,12 @@ class Updates_5_1_0 extends PiwikUpdates
         $ranges = $this->getValidRanges($pluginConfig[Configuration::KEY_RANGE_ALLOW_LIST]);
 
         if (!empty($ranges)) {
-            $backend = (new Factory())->getPluginStorage('TrackingSpamPrevention', '')->getBackend();
+            $settings = StaticContainer::get(SystemSettings::class);
+            $settings->ipAllowList->setIsWritableByCurrentUser(true);
 
-            if (empty($backend->loadValue('ip_allow_list'))) {
-                $backend->saveValue('ip_allow_list', $ranges);
-                Cache::clearCache();
+            if (empty($settings->ipAllowList->getValue())) {
+                $settings->ipAllowList->setValue($ranges);
+                $settings->save();
             }
         }
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,12 +2,14 @@
 
 __How do I allow specific IPs to not be blocked?__
 
-Say you are using AWS to replay your traffic using log analytics. When you have the block clouds feature enabled, all the requests from your AWS would be blocked. However, you can specifically allow your own IPs to be allowed and not blocked by editing your `config/config.ini.php` file and configuring a list of allowed IP ranges like this:
+Say you are using AWS to replay your traffic using log analytics. When you have the block clouds feature enabled, all the requests from your AWS would be blocked. However, you can specifically allow your own IPs to be allowed and not blocked using the "IP allow list" setting in "Administration => General Settings". Enter one IP address or CIDR range per line.
+
+Alternatively, you can force a list of allowed IP ranges by editing your `config/config.ini.php` file like this (this overrides the setting and makes it read-only in the UI):
 
 ```
 [TrackingSpamPrevention]
-iprange_allowlist[] = "127.0.0.1/32"
-iprange_allowlist[] = "192.168.0.0/21"
+ip_allow_list[] = "127.0.0.1/32"
+ip_allow_list[] = "192.168.0.0/21"
 ```
 
 Make sure to enter a valid IP range. 

--- a/lang/en.json
+++ b/lang/en.json
@@ -15,6 +15,8 @@
         "SettingExcludedCountriesTitle": "Exclude Countries",
         "SettingExcludedCountriesDescription": "Don't track visitors from these countries. Visitors outside your target area will likely be bots or spammers, or you can use it to avoid privacy laws in other jurisdictions.",
         "SettingIncludedCountriesTitle": "Only track visitors from these countries",
-        "SettingIncludedCountriesDescription": "This excludes all other countries. The \"exclude countries\" setting has more info."
+        "SettingIncludedCountriesDescription": "This excludes all other countries. The \"exclude countries\" setting has more info.",
+        "SettingIpAllowListTitle": "IP allow list",
+        "SettingIpAllowListHelp": "Specify the IP addresses or CIDR ranges that are allowed to send tracking requests. Enter one value per line."
     }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "TrackingSpamPrevention",
     "description": "This plugin offers various options to prevent spammers and bots from making your data inaccurate so you can rely on your data again.",
-    "version": "5.0.11",
+    "version": "5.1.0",
     "theme": false,
     "require": {
         "matomo": ">=5.0.0-b1,<6.0.0-b1"

--- a/tests/Integration/AllowListIpRangeTest.php
+++ b/tests/Integration/AllowListIpRangeTest.php
@@ -9,9 +9,8 @@
 
 namespace Piwik\Plugins\TrackingSpamPrevention\tests\Integration;
 
-use Piwik\Config;
 use Piwik\Plugins\TrackingSpamPrevention\AllowListIpRange;
-use Piwik\Plugins\TrackingSpamPrevention\Configuration;
+use Piwik\Plugins\TrackingSpamPrevention\SystemSettings;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
 /**
@@ -22,6 +21,11 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 class AllowListIpRangeTest extends IntegrationTestCase
 {
     /**
+     * @var SystemSettings
+     */
+    private $settings;
+
+    /**
      * @var AllowListIpRange
      */
     private $allowList;
@@ -30,12 +34,13 @@ class AllowListIpRangeTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->allowList = new AllowListIpRange(new Configuration());
+        $this->settings = new SystemSettings();
+        $this->allowList = new AllowListIpRange($this->settings);
     }
 
     public function test_isAllowed()
     {
-        Config::getInstance()->TrackingSpamPrevention[Configuration::KEY_RANGE_ALLOW_LIST] = ['10.10.0.0/21', '15.15.0.0/21', '2001:db8::/64'];
+        $this->settings->ipAllowList->setValue(['10.10.0.0/21', '15.15.0.0/21', '2001:db8::/64']);
 
         $this->assertTrue($this->allowList->isAllowed('10.10.0.0'));
         $this->assertTrue($this->allowList->isAllowed('10.10.0.1'));
@@ -49,5 +54,21 @@ class AllowListIpRangeTest extends IntegrationTestCase
 
         $this->assertFalse($this->allowList->isAllowed('2001:db8:0000:0001:ffff:ffff:ffff:fffe'));
         $this->assertFalse($this->allowList->isAllowed('2002:db8:0000:0000:ffff:ffff:ffff:fffe'));
+    }
+
+    public function test_isAllowed_bareIpsMatchWithoutExplicitRange()
+    {
+        $this->settings->ipAllowList->setValue(['12.14.15.16', 'f::f']);
+
+        $this->assertTrue($this->allowList->isAllowed('12.14.15.16'));
+        $this->assertTrue($this->allowList->isAllowed('f::f'));
+
+        $this->assertFalse($this->allowList->isAllowed('12.14.15.17'));
+        $this->assertFalse($this->allowList->isAllowed('f::e'));
+    }
+
+    public function test_isAllowed_emptyList()
+    {
+        $this->assertFalse($this->allowList->isAllowed('10.10.0.0'));
     }
 }

--- a/tests/Integration/ConfigurationTest.php
+++ b/tests/Integration/ConfigurationTest.php
@@ -10,7 +10,9 @@
 namespace Piwik\Plugins\TrackingSpamPrevention\tests\Integration;
 
 use Piwik\Config;
+use Piwik\Container\StaticContainer;
 use Piwik\Plugins\TrackingSpamPrevention\Configuration;
+use Piwik\Plugins\TrackingSpamPrevention\SystemSettings;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
 /**
@@ -36,12 +38,14 @@ class ConfigurationTest extends IntegrationTestCase
 
     public function test_shouldInstallConfig()
     {
+        // reset the section as the local config of the instance running the tests may contain different values
+        Config::getInstance()->TrackingSpamPrevention = [];
+
         $this->configuration->install();
 
         $configs = Config::getInstance()->TrackingSpamPrevention;
         $this->assertEquals(array(
             'block_cloud_sync_throw_exception_on_error' => 0,
-            'iprange_allowlist' => [''],
             'block_geoip_organisations' => Configuration::DEFAULT_GEOIP_MATCH_PROVIDERS,
         ), $configs);
     }
@@ -62,19 +66,10 @@ class ConfigurationTest extends IntegrationTestCase
         $this->assertSame([], $this->configuration->getIpRangesAlwaysAllowed());
     }
 
-    public function test_getIpRangesAlwaysAllowed_custom()
+    public function test_getIpRangesAlwaysAllowed_delegatesToSystemSetting()
     {
-        Config::getInstance()->TrackingSpamPrevention = array(
-            Configuration::KEY_RANGE_ALLOW_LIST => ['10.12.13.14/32', 'f::f/52', '', '11.12.13.14/21', '12.14.15.16', 'f::f']
-        );
-        $this->assertSame(['10.12.13.14/32', 'f::f/52', '11.12.13.14/21', '12.14.15.16/32', 'f::f/128'], $this->configuration->getIpRangesAlwaysAllowed());
-    }
+        StaticContainer::get(SystemSettings::class)->ipAllowList->setValue(['10.12.13.14/32', 'f::f/52', '11.12.13.14/21']);
 
-    public function test_getIpRangesAlwaysAllowed_invalid()
-    {
-        Config::getInstance()->TrackingSpamPrevention = array(
-            Configuration::KEY_RANGE_ALLOW_LIST => 'foobar'
-        );
-        $this->assertSame([], $this->configuration->getIpRangesAlwaysAllowed());
+        $this->assertSame(['10.12.13.14/32', 'f::f/52', '11.12.13.14/21'], $this->configuration->getIpRangesAlwaysAllowed());
     }
 }

--- a/tests/Integration/SystemSettingsTest.php
+++ b/tests/Integration/SystemSettingsTest.php
@@ -138,6 +138,41 @@ class SystemSettingsTest extends IntegrationTestCase
         $this->assertSame([], $this->settings->getIncludedCountryCodes());
     }
 
+    public function test_ipAllowList_default()
+    {
+        $this->assertSame([], $this->settings->ipAllowList->getValue());
+    }
+
+    public function test_getAllowedIpRanges_default()
+    {
+        $this->assertSame([], $this->settings->getAllowedIpRanges());
+    }
+
+    public function test_ipAllowList_transformTrimsFiltersAndDeduplicates()
+    {
+        $this->settings->ipAllowList->setValue([' 10.10.0.0/21 ', '', '10.10.0.0/21', '12.14.15.16', '  ', 'f::f']);
+        $this->assertSame(['10.10.0.0/21', '12.14.15.16', 'f::f'], $this->settings->ipAllowList->getValue());
+    }
+
+    public function test_ipAllowList_acceptsValidIpsRangesAndCidrNotations()
+    {
+        $ranges = ['10.10.0.1', '10.10.0.0/21', '10.10.*.*', 'f::f', '2001:db8::/64'];
+        $this->settings->ipAllowList->setValue($ranges);
+        $this->assertSame($ranges, $this->settings->ipAllowList->getValue());
+    }
+
+    public function test_ipAllowList_rejectsInvalidEntries()
+    {
+        $this->expectException(\Exception::class);
+        $this->settings->ipAllowList->setValue(['10.10.0.1', 'foobar']);
+    }
+
+    public function test_getAllowedIpRanges_returnsCleanedValues()
+    {
+        $this->settings->ipAllowList->setValue(['10.10.0.0/21', '12.14.15.16']);
+        $this->assertSame(['10.10.0.0/21', '12.14.15.16'], $this->settings->getAllowedIpRanges());
+    }
+
     public function test_save_shouldSyncWhenEnabled()
     {
         $ranges = $this->makeRanges();

--- a/tests/Integration/Tracker/RequestProcessorTest.php
+++ b/tests/Integration/Tracker/RequestProcessorTest.php
@@ -9,7 +9,6 @@
 
 namespace Piwik\Plugins\TrackingSpamPrevention\tests\Integration\Tracker;
 
-use Piwik\Config;
 use Piwik\Plugins\TrackingSpamPrevention\BlockedIpRanges;
 use Piwik\Plugins\TrackingSpamPrevention\Configuration;
 use Piwik\Plugins\TrackingSpamPrevention\SystemSettings;
@@ -80,9 +79,7 @@ class RequestProcessorTest extends IntegrationTestCase
 
     public function test_updateBlockedIpRanges_maxActionsEnabled_limitReached_shouldIgnoreAllowedIp()
     {
-        Config::getInstance()->TrackingSpamPrevention = [
-            Configuration::KEY_RANGE_ALLOW_LIST => ['10.12.13.14/32', 'f::f/52', '', '11.12.13.14/21', '12.14.15.16', 'f::f']
-        ];
+        $this->settings->ipAllowList->setValue(['10.12.13.14/32', 'f::f/52', '', '11.12.13.14/21', '12.14.15.16', 'f::f']);
         $this->settings->max_actions->setValue(200);
 
         $this->assertNull($this->processor->afterRequestProcessed($this->makeVisit(200), $this->makeRequest()));
@@ -91,9 +88,7 @@ class RequestProcessorTest extends IntegrationTestCase
 
     public function test_updateBlockedIpRanges_maxActionsEnabled_limitReached_shouldIgnoreAllowedIpHigherActions()
     {
-        Config::getInstance()->TrackingSpamPrevention = [
-            Configuration::KEY_RANGE_ALLOW_LIST => ['10.12.13.14/32', 'f::f/52', '', '11.12.13.14/21', '12.14.15.16', 'f::f']
-        ];
+        $this->settings->ipAllowList->setValue(['10.12.13.14/32', 'f::f/52', '', '11.12.13.14/21', '12.14.15.16', 'f::f']);
         $this->settings->max_actions->setValue(200);
 
         $this->assertNull($this->processor->afterRequestProcessed($this->makeVisit(800), $this->makeRequest()));

--- a/tests/Integration/TrackingSpamPreventionTest.php
+++ b/tests/Integration/TrackingSpamPreventionTest.php
@@ -9,10 +9,8 @@
 
 namespace Piwik\Plugins\TrackingSpamPrevention\tests\Integration;
 
-use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Plugins\TrackingSpamPrevention\BlockedIpRanges;
-use Piwik\Plugins\TrackingSpamPrevention\Configuration;
 use Piwik\Plugins\TrackingSpamPrevention\SystemSettings;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -172,9 +170,9 @@ class TrackingSpamPreventionTest extends IntegrationTestCase
 
     public function test_isExcludedVisit_whenWhiteListUsed()
     {
-        Config::getInstance()->TrackingSpamPrevention[Configuration::KEY_RANGE_ALLOW_LIST] = [
+        StaticContainer::get(SystemSettings::class)->ipAllowList->setValue([
             '10.10.0.4/32', '10.10.0.3/32',
-        ];
+        ]);
         $excluded = $this->makeExcluded('10.10.0.2');
         $this->assertTrue($excluded->isExcluded());
 

--- a/tests/Integration/UpdatesTest.php
+++ b/tests/Integration/UpdatesTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\TrackingSpamPrevention\tests\Integration;
+
+use Piwik\Config;
+use Piwik\Plugins\TrackingSpamPrevention\Configuration;
+use Piwik\Plugins\TrackingSpamPrevention\SystemSettings;
+use Piwik\Plugins\TrackingSpamPrevention\Updates_5_1_0;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Updater;
+
+require_once PIWIK_INCLUDE_PATH . '/plugins/TrackingSpamPrevention/Updates/5.1.0.php';
+
+/**
+ * @group TrackingSpamPrevention
+ * @group UpdatesTest
+ * @group Plugins
+ */
+class UpdatesTest extends IntegrationTestCase
+{
+    public function test_update_migratesConfigValuesToSystemSetting()
+    {
+        Config::getInstance()->TrackingSpamPrevention = [
+            Configuration::KEY_RANGE_ALLOW_LIST => [' 10.10.0.0/21 ', '', 'foobar', '12.14.15.16', '10.10.0.0/21', 'f::f'],
+        ];
+
+        $this->runUpdate();
+
+        $this->assertSame(['10.10.0.0/21', '12.14.15.16', 'f::f'], $this->makeSettings()->getAllowedIpRanges());
+        $this->assertArrayNotHasKey(Configuration::KEY_RANGE_ALLOW_LIST, Config::getInstance()->TrackingSpamPrevention);
+    }
+
+    public function test_update_installDefaultOnly_doesNotWriteSettingButRemovesKey()
+    {
+        Config::getInstance()->TrackingSpamPrevention = [
+            Configuration::KEY_RANGE_ALLOW_LIST => Configuration::DEFAULT_RANGE_ALLOW_LIST,
+        ];
+
+        $this->runUpdate();
+
+        $this->assertSame([], $this->makeSettings()->getAllowedIpRanges());
+        $this->assertArrayNotHasKey(Configuration::KEY_RANGE_ALLOW_LIST, Config::getInstance()->TrackingSpamPrevention);
+    }
+
+    public function test_update_configKeyAbsent_isNoOp()
+    {
+        Config::getInstance()->TrackingSpamPrevention = [];
+
+        $this->runUpdate();
+
+        $this->assertSame([], $this->makeSettings()->getAllowedIpRanges());
+    }
+
+    public function test_update_doesNotOverwriteExistingSettingValue()
+    {
+        $settings = $this->makeSettings();
+        $settings->ipAllowList->setValue(['20.20.0.0/21']);
+        $settings->save();
+
+        Config::getInstance()->TrackingSpamPrevention = [
+            Configuration::KEY_RANGE_ALLOW_LIST => ['10.10.0.0/21'],
+        ];
+
+        $this->runUpdate();
+
+        $this->assertSame(['20.20.0.0/21'], $this->makeSettings()->getAllowedIpRanges());
+        $this->assertArrayNotHasKey(Configuration::KEY_RANGE_ALLOW_LIST, Config::getInstance()->TrackingSpamPrevention);
+    }
+
+    private function runUpdate()
+    {
+        $update = new Updates_5_1_0();
+        $update->doUpdate(new Updater());
+    }
+
+    private function makeSettings(): SystemSettings
+    {
+        return new SystemSettings();
+    }
+}

--- a/tests/UI/expected-screenshots/TrackingSpamPreventionSettings_page.png
+++ b/tests/UI/expected-screenshots/TrackingSpamPreventionSettings_page.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d07cd24a78dc5c01d7034e89bbf0bf40f3b46fc054191a6ea6118691b17e7557
-size 165455
+oid sha256:12d8c1da6a37aab2d70be3da34031306c49867d282d6bd125ffcef3145ba0c35
+size 183609


### PR DESCRIPTION
## Description
Adds an "IP allow list" system setting (multi-line textarea, one IP/CIDR range per line) under General Settings so the tracking-spam allow list can be managed in the UI, e.g. by Cloud users who cannot edit config files. A 5.1.0 update migrates existing `iprange_allowlist` config values into the new `ip_allow_list` setting and removes the old key from the config file. `Configuration::getIpRangesAlwaysAllowed()` is deprecated in favour of `SystemSettings::getAllowedIpRanges()`, and `AllowListIpRange` now takes `SystemSettings` in its constructor instead of `Configuration`.

Automation can still pin the list via `[TrackingSpamPrevention] ip_allow_list[] = "..."` in config, which core honours; while the override is in place the setting is hidden from the UI (documented in the FAQ).

## Issue No
PG-3570

## Steps to Replicate the Issue
1. As a Cloud user, have legitimate traffic blocked by TrackingSpamPrevention (e.g. flagged as a headless browser).
2. Expected: allow-list the source IPs in the UI. Actual: `iprange_allowlist` was only configurable via `config.ini.php`, which Cloud users cannot edit.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [✔] Are all newly added texts included via translation?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)
