### PR TITLE
Add IP block list setting to the UI, PG-5272

### DIFF
--- a/BlockListIpRange.php
+++ b/BlockListIpRange.php
@@ -25,7 +25,7 @@ class BlockListIpRange
 
     public function isBlocked($ip)
     {
-        $rangesBlocked = $this->settings->getBlockedIpRanges();
+        $rangesBlocked = $this->settings->getBlockListIpRanges();
 
         if (!empty($rangesBlocked)) {
             $ip  = IP::fromStringIP($ip);

--- a/BlockListIpRange.php
+++ b/BlockListIpRange.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\TrackingSpamPrevention;
+
+use Matomo\Network\IP;
+
+class BlockListIpRange
+{
+    /**
+     * @var SystemSettings
+     */
+    private $settings;
+
+    public function __construct(SystemSettings $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    public function isBlocked($ip)
+    {
+        $rangesBlocked = $this->settings->getBlockedIpRanges();
+
+        if (!empty($rangesBlocked)) {
+            $ip  = IP::fromStringIP($ip);
+            return $ip->isInRanges($rangesBlocked);
+        }
+
+        return false;
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # 5.1.0 - 2026-08-03
 - Added an "IP allow list" setting to the UI (General Settings). Existing `iprange_allowlist` config values are migrated to the new `ip_allow_list` system setting and removed from the config file
+- Added an "IP block list" setting to the UI (General Settings) to block tracking requests from specific IP addresses or ranges
 
 # 5.0.11 - 2026-07-06
 - Enabled block headless browser by default

--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -46,6 +46,9 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     /** @var Setting */
     public $ipAllowList;
 
+    /** @var Setting */
+    public $ipBlockList;
+
     protected function init()
     {
         $this->block_clouds = $this->createBlockCloudsSetting();
@@ -61,6 +64,11 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
             'ip_allow_list',
             'TrackingSpamPrevention_SettingIpAllowListTitle',
             'TrackingSpamPrevention_SettingIpAllowListHelp'
+        );
+        $this->ipBlockList = $this->makeIpRangeListSetting(
+            'ip_block_list',
+            'TrackingSpamPrevention_SettingIpBlockListTitle',
+            'TrackingSpamPrevention_SettingIpBlockListHelp'
         );
     }
 
@@ -245,7 +253,17 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
 
     public function getAllowedIpRanges(): array
     {
-        $value = $this->ipAllowList->getValue();
+        return $this->settingToIpRanges($this->ipAllowList);
+    }
+
+    public function getBlockedIpRanges(): array
+    {
+        return $this->settingToIpRanges($this->ipBlockList);
+    }
+
+    private function settingToIpRanges(Setting $setting): array
+    {
+        $value = $setting->getValue();
 
         if (empty($value) || !is_array($value)) {
             return [];

--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -256,7 +256,7 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         return $this->settingToIpRanges($this->ipAllowList);
     }
 
-    public function getBlockedIpRanges(): array
+    public function getBlockListIpRanges(): array
     {
         return $this->settingToIpRanges($this->ipBlockList);
     }

--- a/TrackingSpamPrevention.php
+++ b/TrackingSpamPrevention.php
@@ -91,6 +91,12 @@ class TrackingSpamPrevention extends \Piwik\Plugin
             return;
         }
 
+        if (StaticContainer::get(BlockListIpRange::class)->isBlocked($ipString)) {
+            Common::printDebug("Excluding visit as it matches an IP range on the block list");
+            $excluded = 'excluded: ip block list';
+            return;
+        }
+
         $settings = $this->getSystemSettings();
         $blockGeoIp = $this->getBlockGeoIp();
         $browserLang = $request->getBrowserLanguage();

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -14,6 +14,18 @@ ip_allow_list[] = "192.168.0.0/21"
 
 Make sure to enter a valid IP range. 
 
+__How do I block specific IPs from being tracked?__
+
+Use the "IP block list" setting in "Administration => General Settings". Enter one IP address or CIDR range per line. If an address matches both the allow list and the block list, the allow list takes precedence.
+
+Alternatively, you can force a list of blocked IP ranges by editing your `config/config.ini.php` file like this (this overrides the setting and makes it read-only in the UI):
+
+```
+[TrackingSpamPrevention]
+ip_block_list[] = "203.0.113.88/32"
+ip_block_list[] = "198.51.100.0/24"
+```
+
 __What happens when it fails to synchronise public IPs from cloud providers?__
 
 Any error is currently ignored and if it does not synchronise successfully, then the IP for the provider that failed are not synced.

--- a/lang/en.json
+++ b/lang/en.json
@@ -17,6 +17,8 @@
         "SettingIncludedCountriesTitle": "Only track visitors from these countries",
         "SettingIncludedCountriesDescription": "This excludes all other countries. The \"exclude countries\" setting has more info.",
         "SettingIpAllowListTitle": "IP allow list",
-        "SettingIpAllowListHelp": "Specify the IP addresses or CIDR ranges that are allowed to send tracking requests. Enter one value per line."
+        "SettingIpAllowListHelp": "Specify the IP addresses or CIDR ranges that are allowed to send tracking requests. Enter one value per line.",
+        "SettingIpBlockListTitle": "IP block list",
+        "SettingIpBlockListHelp": "Specify the IP addresses or CIDR ranges to block from sending tracking requests. Enter one value per line."
     }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -19,6 +19,6 @@
         "SettingIpAllowListTitle": "IP allow list",
         "SettingIpAllowListHelp": "Specify the IP addresses or CIDR ranges that are allowed to send tracking requests. Enter one value per line.",
         "SettingIpBlockListTitle": "IP block list",
-        "SettingIpBlockListHelp": "Specify the IP addresses or CIDR ranges to block from sending tracking requests. Enter one value per line."
+        "SettingIpBlockListHelp": "Specify the IP addresses or CIDR ranges to block from sending tracking requests. Enter one value per line. Matomo may block additional IPs automatically, such as cloud provider IP ranges fetched daily when \"Block tracking requests from the cloud\" is enabled, or IPs banned temporarily for exceeding the max actions limit."
     }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -19,6 +19,6 @@
         "SettingIpAllowListTitle": "IP allow list",
         "SettingIpAllowListHelp": "Specify the IP addresses or CIDR ranges that are allowed to send tracking requests. Enter one value per line.",
         "SettingIpBlockListTitle": "IP block list",
-        "SettingIpBlockListHelp": "Specify the IP addresses or CIDR ranges to block from sending tracking requests. Enter one value per line. Matomo may block additional IPs automatically, such as cloud provider IP ranges fetched daily when \"Block tracking requests from the cloud\" is enabled, or IPs banned temporarily for exceeding the max actions limit."
+        "SettingIpBlockListHelp": "Specify the IP addresses or CIDR ranges to block from sending tracking requests. Enter one value per line. Matomo may block additional IPs automatically that won't appear in this list, such as cloud provider IP ranges fetched daily when \"Block tracking requests from the cloud\" is enabled, or IPs banned temporarily for exceeding the max actions limit."
     }
 }

--- a/tests/Integration/BlockListIpRangeTest.php
+++ b/tests/Integration/BlockListIpRangeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\TrackingSpamPrevention\tests\Integration;
+
+use Piwik\Plugins\TrackingSpamPrevention\BlockListIpRange;
+use Piwik\Plugins\TrackingSpamPrevention\SystemSettings;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group TrackingSpamPrevention
+ * @group BlockListIpRangeTest
+ * @group Plugins
+ */
+class BlockListIpRangeTest extends IntegrationTestCase
+{
+    /**
+     * @var SystemSettings
+     */
+    private $settings;
+
+    /**
+     * @var BlockListIpRange
+     */
+    private $blockList;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->settings = new SystemSettings();
+        $this->blockList = new BlockListIpRange($this->settings);
+    }
+
+    public function test_isBlocked()
+    {
+        $this->settings->ipBlockList->setValue(['10.10.0.0/21', '15.15.0.0/21', '2001:db8::/64']);
+
+        $this->assertTrue($this->blockList->isBlocked('10.10.0.0'));
+        $this->assertTrue($this->blockList->isBlocked('10.10.0.1'));
+        $this->assertTrue($this->blockList->isBlocked('10.10.0.255'));
+        $this->assertTrue($this->blockList->isBlocked('15.15.0.255'));
+
+        $this->assertFalse($this->blockList->isBlocked('11.11.0.0'));
+
+        $this->assertTrue($this->blockList->isBlocked('2001:db8::'));
+        $this->assertTrue($this->blockList->isBlocked('2001:db8:0000:0000:ffff:ffff:ffff:fffe'));
+
+        $this->assertFalse($this->blockList->isBlocked('2001:db8:0000:0001:ffff:ffff:ffff:fffe'));
+        $this->assertFalse($this->blockList->isBlocked('2002:db8:0000:0000:ffff:ffff:ffff:fffe'));
+    }
+
+    public function test_isBlocked_bareIpsMatchWithoutExplicitRange()
+    {
+        $this->settings->ipBlockList->setValue(['12.14.15.16', 'f::f']);
+
+        $this->assertTrue($this->blockList->isBlocked('12.14.15.16'));
+        $this->assertTrue($this->blockList->isBlocked('f::f'));
+
+        $this->assertFalse($this->blockList->isBlocked('12.14.15.17'));
+        $this->assertFalse($this->blockList->isBlocked('f::e'));
+    }
+
+    public function test_isBlocked_emptyList()
+    {
+        $this->assertFalse($this->blockList->isBlocked('10.10.0.0'));
+    }
+}

--- a/tests/Integration/SystemSettingsTest.php
+++ b/tests/Integration/SystemSettingsTest.php
@@ -178,9 +178,9 @@ class SystemSettingsTest extends IntegrationTestCase
         $this->assertSame([], $this->settings->ipBlockList->getValue());
     }
 
-    public function test_getBlockedIpRanges_default()
+    public function test_getBlockListIpRanges_default()
     {
-        $this->assertSame([], $this->settings->getBlockedIpRanges());
+        $this->assertSame([], $this->settings->getBlockListIpRanges());
     }
 
     public function test_ipBlockList_transformTrimsFiltersAndDeduplicates()
@@ -195,10 +195,10 @@ class SystemSettingsTest extends IntegrationTestCase
         $this->settings->ipBlockList->setValue(['10.10.0.1', 'foobar']);
     }
 
-    public function test_getBlockedIpRanges_returnsCleanedValues()
+    public function test_getBlockListIpRanges_returnsCleanedValues()
     {
         $this->settings->ipBlockList->setValue(['10.10.0.0/21', '12.14.15.16']);
-        $this->assertSame(['10.10.0.0/21', '12.14.15.16'], $this->settings->getBlockedIpRanges());
+        $this->assertSame(['10.10.0.0/21', '12.14.15.16'], $this->settings->getBlockListIpRanges());
     }
 
     public function test_save_shouldSyncWhenEnabled()

--- a/tests/Integration/SystemSettingsTest.php
+++ b/tests/Integration/SystemSettingsTest.php
@@ -173,6 +173,34 @@ class SystemSettingsTest extends IntegrationTestCase
         $this->assertSame(['10.10.0.0/21', '12.14.15.16'], $this->settings->getAllowedIpRanges());
     }
 
+    public function test_ipBlockList_default()
+    {
+        $this->assertSame([], $this->settings->ipBlockList->getValue());
+    }
+
+    public function test_getBlockedIpRanges_default()
+    {
+        $this->assertSame([], $this->settings->getBlockedIpRanges());
+    }
+
+    public function test_ipBlockList_transformTrimsFiltersAndDeduplicates()
+    {
+        $this->settings->ipBlockList->setValue([' 10.10.0.0/21 ', '', '10.10.0.0/21', '12.14.15.16', '  ', 'f::f']);
+        $this->assertSame(['10.10.0.0/21', '12.14.15.16', 'f::f'], $this->settings->ipBlockList->getValue());
+    }
+
+    public function test_ipBlockList_rejectsInvalidEntries()
+    {
+        $this->expectException(\Exception::class);
+        $this->settings->ipBlockList->setValue(['10.10.0.1', 'foobar']);
+    }
+
+    public function test_getBlockedIpRanges_returnsCleanedValues()
+    {
+        $this->settings->ipBlockList->setValue(['10.10.0.0/21', '12.14.15.16']);
+        $this->assertSame(['10.10.0.0/21', '12.14.15.16'], $this->settings->getBlockedIpRanges());
+    }
+
     public function test_save_shouldSyncWhenEnabled()
     {
         $ranges = $this->makeRanges();

--- a/tests/Integration/TrackingSpamPreventionTest.php
+++ b/tests/Integration/TrackingSpamPreventionTest.php
@@ -192,6 +192,29 @@ class TrackingSpamPreventionTest extends IntegrationTestCase
         $this->assertFalse($excluded->isExcluded());
     }
 
+    public function test_isExcludedVisit_whenIpOnBlockList()
+    {
+        StaticContainer::get(SystemSettings::class)->ipBlockList->setValue([
+            '203.0.113.88/32', '198.51.100.0/24',
+        ]);
+
+        $this->assertTrue($this->makeExcluded('203.0.113.88')->isExcluded());
+        $this->assertTrue($this->makeExcluded('198.51.100.55')->isExcluded());
+
+        $this->assertFalse($this->makeExcluded('203.0.113.89')->isExcluded());
+        $this->assertFalse($this->makeExcluded('198.51.101.1')->isExcluded());
+    }
+
+    public function test_isExcludedVisit_allowListTakesPrecedenceOverBlockList()
+    {
+        $settings = StaticContainer::get(SystemSettings::class);
+        $settings->ipAllowList->setValue(['203.0.113.88/32']);
+        $settings->ipBlockList->setValue(['203.0.113.0/24']);
+
+        $this->assertFalse($this->makeExcluded('203.0.113.88')->isExcluded());
+        $this->assertTrue($this->makeExcluded('203.0.113.89')->isExcluded());
+    }
+
     public function test_isExcludedVisit_excludeCountries()
     {
         StaticContainer::get(SystemSettings::class)->excludedCountries->setValue(

--- a/tests/System/CheckDirectDependencyUseCommandTest.php
+++ b/tests/System/CheckDirectDependencyUseCommandTest.php
@@ -45,6 +45,7 @@ class CheckDirectDependencyUseCommandTest extends SystemTestCase
             ],
             'Matomo\Network' => [
                 'TrackingSpamPrevention/AllowListIpRange.php',
+                'TrackingSpamPrevention/BlockListIpRange.php',
                 'TrackingSpamPrevention/BlockedIpRanges.php',
                 'TrackingSpamPrevention/TrackingSpamPrevention.php',
             ],

--- a/tests/UI/expected-screenshots/TrackingSpamPreventionSettings_page.png
+++ b/tests/UI/expected-screenshots/TrackingSpamPreventionSettings_page.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:111b0a78c861796849aadd9aaaabc6787b52d576d5ba3ea036444a242b19d193
-size 201687
+oid sha256:c57a1d398849580946ad6fab9e0fca38de79c59ebcffcbea92e1ddcb3d5672b1
+size 219913

--- a/tests/UI/expected-screenshots/TrackingSpamPreventionSettings_page.png
+++ b/tests/UI/expected-screenshots/TrackingSpamPreventionSettings_page.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:12d8c1da6a37aab2d70be3da34031306c49867d282d6bd125ffcef3145ba0c35
-size 183609
+oid sha256:111b0a78c861796849aadd9aaaabc6787b52d576d5ba3ea036444a242b19d193
+size 201687

--- a/tests/UI/expected-screenshots/TrackingSpamPreventionSettings_page.png
+++ b/tests/UI/expected-screenshots/TrackingSpamPreventionSettings_page.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c57a1d398849580946ad6fab9e0fca38de79c59ebcffcbea92e1ddcb3d5672b1
-size 219913
+oid sha256:5f867a79562c841bddb43bedf80f62d142e015c7bf05a252e43891bd4f721811
+size 221402


### PR DESCRIPTION
## Description
Adds an "IP block list" system setting (multi-line textarea, one IP/CIDR range per line) under General Settings so tracking requests from specific IPs can be blocked in the UI. Builds on the IP allow list from #176 (stacked PR — merge that first; this shows only the block-list diff and ships in the same 5.1.0 release).

- The allow list takes precedence when an address matches both lists (checked first in `isExcludedVisit`, covered by a test).
- The manual list works alongside the existing automatic blocklist (synced cloud-provider ranges + temporary max-actions bans in the `TrackingSpamBlockedIpRanges` option) — both checks run per request.
- No migration, deliberately: unlike the allow list there has never been a config key for a manual IP block list (verified in code, git history, and the published plugin FAQ), and the option is an auto-rebuilt cache of synced ranges and 24h bans that must not become permanent manual entries. Automation can pin the list via `[TrackingSpamPrevention] ip_block_list[] = "..."` (core config override, documented in the FAQ).

## Issue No
PG-5272

## Steps to Replicate the Issue
1. As a Cloud user, receive spam tracking requests from known IP addresses.
2. Expected: block those IPs/ranges in the UI. Actual: no manual IP block list existed — only the automatic cloud-provider blocking and config-only workarounds.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [✔] Are all newly added texts included via translation?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)