### PR TITLE
Update UI Screenshots after switching primary brand color

### DIFF
--- a/tests/UI/expected-screenshots/TrackingSpamPreventionSettings_page.png
+++ b/tests/UI/expected-screenshots/TrackingSpamPreventionSettings_page.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1303d2967a0199a562198b725ae044af564eb727ce9578abfb03748a95d8d7ae
-size 153030
+oid sha256:7f63195dc690a65f3c74aec823148120f88fdcc6c69e0d1ad7697e42965f99ea
+size 153009


### PR DESCRIPTION
## Description

Update UI screenshots after small color update in the Morpheus theme to introduce the dark mode.

This update should follow the merge of this PR:

- https://github.com/matomo-org/matomo/pull/24891

issue dev-20496

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules
