### PR TITLE
Correct FAQ: config-overridden IP lists are hidden from the UI, not read-only

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,7 +4,7 @@ __How do I allow specific IPs to not be blocked?__
 
 Say you are using AWS to replay your traffic using log analytics. When you have the block clouds feature enabled, all the requests from your AWS would be blocked. However, you can specifically allow your own IPs to be allowed and not blocked using the "IP allow list" setting in "Administration => General Settings". Enter one IP address or CIDR range per line.
 
-Alternatively, you can force a list of allowed IP ranges by editing your `config/config.ini.php` file like this (this overrides the setting and makes it read-only in the UI):
+Alternatively, you can force a list of allowed IP ranges by editing your `config/config.ini.php` file like this (this overrides the setting, and the field is hidden from the UI while the override is in place):
 
 ```
 [TrackingSpamPrevention]
@@ -18,7 +18,7 @@ __How do I block specific IPs from being tracked?__
 
 Use the "IP block list" setting in "Administration => General Settings". Enter one IP address or CIDR range per line. If an address matches both the allow list and the block list, the allow list takes precedence.
 
-Alternatively, you can force a list of blocked IP ranges by editing your `config/config.ini.php` file like this (this overrides the setting and makes it read-only in the UI):
+Alternatively, you can force a list of blocked IP ranges by editing your `config/config.ini.php` file like this (this overrides the setting, and the field is hidden from the UI while the override is in place):
 
 ```
 [TrackingSpamPrevention]


### PR DESCRIPTION
## Description
Corrects the FAQ wording for the `ip_allow_list` / `ip_block_list` config overrides: while an override is in place the setting is hidden from General Settings, it does not become read-only. The old wording caused confusion when the fields disappeared after adding the config values.

## Issue No
Related to PG-3570 / PG-5272

## Steps to Replicate the Issue
1. Add `ip_allow_list[]` entries under `[TrackingSpamPrevention]` in `config/config.ini.php` and open General Settings.
2. Expected (per current FAQ): the field becomes read-only.
3. Actual: the field is hidden while the override is in place (standard behaviour for plugin settings).

## Checklist
- [NA] Tested locally or on demo2/demo3? (docs-only change)
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✖] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [✔] Documentation updated?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
